### PR TITLE
Add license to Composer and Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 			"homepage" : "https://github.com/riccardonar"
 		}
 	],
+	"license": "MIT",
 	"autoload" : {
         "classmap": ["src/"]
 	},


### PR DESCRIPTION
The license is already included in repository, but not specified in a machine-readable way.

This helps with automated tools checking licenses.